### PR TITLE
Store security patch to conceal Square credentials

### DIFF
--- a/client/app/utils/storeApi.js
+++ b/client/app/utils/storeApi.js
@@ -1,22 +1,7 @@
 import { ajax } from 'rxjs/observable/dom/ajax';
-const config = require('../../../env.json');
 
-// Bring in authorization details specific to this account
-const accessToken = config.SQUARE_ACCESS_TOKEN;
-const location = config.SQUARE_LOCATION;
-
-// Configuration for the HTTP request since Square requires authorization, factor out into secure file
-const itemsRequest = {
-  headers: {
-    Authorization: `Bearer ${accessToken}`,
-  },
-  url: `https://connect.squareup.com/v1/${location}/items`,
-  responseType: 'json',
-  crossDomain: true,
-  createXHR() {
-    return new XMLHttpRequest();
-  },
-};
+// API string to request list of store items from the backend
+const itemsRequest = '/api/store/items';
 
 // Square Store API methods
 export const fetchItems = () => ajax(itemsRequest);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "axios": "^0.16.2",
     "keystone": "^4.0.0-beta.3",
     "underscore": "latest"
   },

--- a/routes/api/store.js
+++ b/routes/api/store.js
@@ -1,0 +1,21 @@
+const axios = require('axios');
+const config = require('../../env.json');
+
+/**
+ * Get the list of store items and their details from Square
+ *
+ * @return {object|null} Returns either the list JSON, or request error
+ */
+exports.storeItems = async (req, res) => {
+  // Bring in authorization details specific to this account
+  const accessToken = config.SQUARE_ACCESS_TOKEN;
+  const location = config.SQUARE_LOCATION;
+  const url = `https://connect.squareup.com/v1/${location}/items`;
+
+  try {
+    const data = await axios.get(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    res.send(data.data);
+  } catch (err) {
+    res.sendStatus(500);
+  }
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -62,6 +62,12 @@ exports = module.exports = function(app) {
     routes.api.posts.getSlug
   );
 
+  // Handle requests to Square on the server to avoid exposing credentials/tokens
+  app.get(
+    '/api/store/items',
+    routes.api.store.storeItems
+  );
+
   // Serve the front-end SPA for non-API requests
   app.get('*', routes.views.index);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,6 +227,13 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.16.2.tgz#ba4f92f17167dfbab40983785454b9ac149c3c6d"
+  dependencies:
+    follow-redirects "^1.2.3"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -1462,7 +1469,7 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2, debug@2.6.0, debug@^2.1.1, debug@^2.2.0:
+debug@2, debug@2.6.0, debug@^2.1.1, debug@^2.2.0, debug@^2.4.5:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
@@ -1935,6 +1942,12 @@ find-parent-dir@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
 
+follow-redirects@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.2.4.tgz#355e8f4d16876b43f577b0d5ce2668b9723214ea"
+  dependencies:
+    debug "^2.4.5"
+
 for-each@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
@@ -2326,6 +2339,10 @@ is-binary-path@^1.0.0:
 is-buffer@^1.0.2, is-buffer@^1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
+
+is-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.5.tgz#1f3b26ef613b214b88cbca23cc6c01d87961eecc"
 
 is-defined@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
-Previous method was importing Square API tokens directly into front-end client and tokens were visible within bundle.js if you looked for them
-Updating client-side code to send an API request to the backend server instead of directly pinging Square API
-Updating server-side with a new route and middleware to handle requests for Square store items. If the route is hit, server requests item data from Square and returns the result to the client so that the credentials are kept privately in the server
-Bringing in Axios for Promise-based server-side HTTP request handling

NOTES:
-Trying out ES7 async/await to handle this route. Changes done on Node 7.7.2 build.