### PR TITLE
Removing redux-sagas middleware

### DIFF
--- a/client/app/store.js
+++ b/client/app/store.js
@@ -6,22 +6,19 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import { fromJS } from 'immutable';
 import { routerMiddleware } from 'react-router-redux';
 import { createEpicMiddleware } from 'redux-observable';
-import createSagaMiddleware from 'redux-saga';
 import createLogger from 'redux-logger';
 import rootEpic from './epics';
 import createReducer from './reducers';
 
-const sagaMiddleware = createSagaMiddleware();
 const epicMiddleware = createEpicMiddleware(rootEpic);
 const logger = createLogger();
 
 export default function configureStore(initialState = {}, history) {
   // Create the store with two middlewares
-  // 1. sagaMiddleware: Makes redux-sagas work
+  // 1. epicMiddleware: Makes redux-observable epics work
   // 2. routerMiddleware: Syncs the location/URL path to the state
   const middlewares = [
     epicMiddleware,
-    sagaMiddleware,
     routerMiddleware(history),
     logger,
   ];
@@ -46,7 +43,6 @@ export default function configureStore(initialState = {}, history) {
   );
 
   // Extensions
-  store.runSaga = sagaMiddleware.run;
   store.asyncReducers = {}; // Async reducer registry
 
   // Make reducers hot reloadable, see http://mxs.is/googmo

--- a/client/app/utils/asyncInjectors.js
+++ b/client/app/utils/asyncInjectors.js
@@ -4,7 +4,6 @@ import isFunction from 'lodash/isFunction';
 import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
 import invariant from 'invariant';
-import warning from 'warning';
 
 import createReducer from '../reducers';
 
@@ -17,7 +16,6 @@ export function checkStore(store) {
     subscribe: isFunction,
     getState: isFunction,
     replaceReducer: isFunction,
-    runSaga: isFunction,
     asyncReducers: isObject,
   };
   invariant(
@@ -46,27 +44,6 @@ export function injectAsyncReducer(store, isValid) {
 }
 
 /**
- * Inject an asynchronously loaded saga
- */
-export function injectAsyncSagas(store, isValid) {
-  return function injectSagas(sagas) {
-    if (!isValid) checkStore(store);
-
-    invariant(
-      Array.isArray(sagas),
-      '(app/utils...) injectAsyncSagas: Expected `sagas` to be an array of generator functions'
-    );
-
-    warning(
-      !isEmpty(sagas),
-      '(app/utils...) injectAsyncSagas: Received an empty `sagas` array'
-    );
-
-    sagas.map(store.runSaga);
-  };
-}
-
-/**
  * Helper for creating injectors
  */
 export function getAsyncInjectors(store) {
@@ -74,6 +51,5 @@ export function getAsyncInjectors(store) {
 
   return {
     injectReducer: injectAsyncReducer(store, true),
-    injectSagas: injectAsyncSagas(store, true),
   };
 }

--- a/client/package.json
+++ b/client/package.json
@@ -90,7 +90,6 @@
       "es6": true
     },
     "plugins": [
-      "redux-saga",
       "react",
       "jsx-a11y"
     ],
@@ -151,8 +150,6 @@
       "react/jsx-no-target-blank": 0,
       "react/require-extension": 0,
       "react/self-closing-comp": 0,
-      "redux-saga/no-yield-in-race": 2,
-      "redux-saga/yield-effects": 2,
       "require-yield": 0,
       "import/no-webpack-loader-syntax": 0
     },
@@ -239,7 +236,6 @@
     "redux": "3.6.0",
     "redux-immutable": "3.0.8",
     "redux-observable": "^0.14.0",
-    "redux-saga": "0.14.0",
     "reselect": "2.5.4",
     "rxjs": "^5.2.0",
     "sanitize.css": "4.1.0",
@@ -276,7 +272,6 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-react": "6.7.1",
-    "eslint-plugin-redux-saga": "0.1.5",
     "eventsource-polyfill": "0.9.6",
     "exports-loader": "0.6.3",
     "file-loader": "0.9.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2616,10 +2616,6 @@ eslint-plugin-react@6.7.1:
     doctrine "^1.2.2"
     jsx-ast-utils "^1.3.3"
 
-eslint-plugin-redux-saga@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-redux-saga/-/eslint-plugin-redux-saga-0.1.5.tgz#39c11811530230ca88171fe89adfc6de6953119a"
-
 eslint@3.11.1:
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.11.1.tgz#408be581041385cba947cd8d1cd2227782b55dbf"
@@ -3463,11 +3459,7 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-he@1.1.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.1.0.tgz#29319d49beec13a9b1f3c4f9b2a6dde4859bb2a7"
-
-he@^1.1.1:
+he@1.1.x, he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
@@ -6581,10 +6573,6 @@ redux-logger@^2.8.1:
 redux-observable@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-0.14.0.tgz#f8d70b5a0d0b6883acfaa392894b4f4c51785206"
-
-redux-saga@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.14.0.tgz#7792bcc9dc57e9ed2484daa95794b154ee472b24"
 
 redux@3.6.0:
   version "3.6.0"


### PR DESCRIPTION
-Async already handled by Redux-Observable Epics
-Reduced inital bundle load size from 245B to 242B (Full build size from 2.31MB -> 2.28MB)